### PR TITLE
Fix MPRouteData type missing gps, fa, and photos fields

### DIFF
--- a/app/ui-components/routes/RouteMap.tsx
+++ b/app/ui-components/routes/RouteMap.tsx
@@ -46,6 +46,9 @@ interface MPRouteData {
   protection: string | null;
   location: string | null;
   url: string;
+  gps: string | null;
+  fa: string | null;
+  photos: string[];
 }
 
 interface ClimbType {


### PR DESCRIPTION
## Summary
- Added missing `gps`, `fa`, and `photos` fields to the `MPRouteData` interface in `RouteMap.tsx`
- These fields were used in the component's JSX but not declared in the type, causing a TypeScript build error

## Test plan
- [x] `pnpm build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)