### PR TITLE
fix: make dashboard mobile friendly

### DIFF
--- a/app/ui-components/routes/RouteMap.tsx
+++ b/app/ui-components/routes/RouteMap.tsx
@@ -912,9 +912,9 @@ export default function RouteMap() {
   }
 
   return (
-    <div className="flex flex-col md:flex-row md:h-full gap-3 md:gap-4">
-      {/* ── Map — top on mobile, right on desktop ── */}
-      <div className="order-1 md:order-2 h-64 md:h-auto md:flex-1 rounded-xl overflow-hidden border border-stone-200 relative">
+    <div className="relative h-full md:flex md:flex-row md:gap-4">
+      {/* ── Map — full screen on mobile, right column on desktop ── */}
+      <div className="absolute inset-0 overflow-hidden border border-stone-200 md:relative md:order-2 md:flex-1 md:rounded-xl">
         <Script
           src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}`}
           strategy="afterInteractive"
@@ -928,8 +928,8 @@ export default function RouteMap() {
         <div ref={mapRef} className="w-full h-full" />
       </div>
 
-      {/* ── Panel — bottom on mobile, left on desktop ── */}
-      <div className="order-2 md:order-1 md:w-72 md:flex-none bg-stone-100 rounded-xl border border-stone-200 md:overflow-y-auto p-4">
+      {/* ── Panel — bottom sheet on mobile, left sidebar on desktop ── */}
+      <div className="absolute inset-x-3 bottom-3 z-[1000] max-h-[48svh] overflow-y-auto rounded-2xl border border-stone-200 bg-stone-100/95 p-4 shadow-xl backdrop-blur-sm md:static md:order-1 md:h-full md:max-h-none md:w-80 md:flex-none md:overflow-y-auto md:rounded-xl md:bg-stone-100 md:shadow-none md:backdrop-blur-none">
         {panelContent}
       </div>
     </div>

--- a/app/ui/dashboard/layout.tsx
+++ b/app/ui/dashboard/layout.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="h-screen overflow-hidden relative">
+    <div className="h-[100svh] overflow-hidden relative">
       {/* Overlay sidenav — fixed positioned, does not affect document flow */}
       <SideNav />
 
@@ -20,7 +20,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           />
         </div>
         {/* Scrollable content sits on top */}
-        <div className="relative z-10 h-full overflow-y-auto p-6 md:p-12">
+        <div className="relative z-10 h-full overflow-y-auto overscroll-contain p-4 pt-16 sm:p-6 sm:pt-16 md:p-12">
           {children}
         </div>
       </div>

--- a/app/ui/dashboard/page.tsx
+++ b/app/ui/dashboard/page.tsx
@@ -5,11 +5,11 @@ import { PlayIcon } from '@heroicons/react/24/solid';
 export default function DashboardPage() {
   return (
     /*
-     * Break out of the layout's p-6 md:p-12 padding so the map fills
-     * edge-to-edge. h-screen + overflow-hidden ensures the map gets a
-     * concrete height to render into (RouteMap uses h-full internally).
+     * Break out of the layout's mobile and desktop padding so the map fills
+     * edge-to-edge. 100svh + overflow-hidden ensures the map gets a
+     * concrete, mobile-safe height to render into (RouteMap uses h-full internally).
      */
-    <div className="-m-6 md:-m-12 h-screen overflow-hidden relative">
+    <div className="-mx-4 -mb-4 -mt-16 sm:-mx-6 sm:-mb-6 sm:-mt-16 md:-m-12 h-[100svh] overflow-hidden relative">
       <RouteMap />
 
       {/*
@@ -18,7 +18,7 @@ export default function DashboardPage() {
        */}
       <Link
         href="/ui/dashboard/get-started"
-        className="fixed top-0 left-1/2 -translate-x-1/2 z-[5000] flex items-center justify-center gap-2 bg-white/95 backdrop-blur-sm hover:bg-white text-stone-800 font-semibold text-sm w-36 hover:w-screen py-3 rounded-b-2xl hover:rounded-none shadow-md hover:shadow-lg border-b border-stone-200/60 transition-all duration-300 ease-in-out"
+        className="fixed top-3 left-1/2 -translate-x-1/2 z-[5000] flex max-w-[calc(100vw-6rem)] items-center justify-center gap-2 rounded-full border border-stone-200/70 bg-white/95 px-4 py-2.5 text-sm font-semibold text-stone-800 shadow-md backdrop-blur-sm transition-all duration-300 ease-in-out hover:bg-white hover:shadow-lg sm:top-0 sm:w-36 sm:rounded-b-2xl sm:rounded-t-none sm:border-x-0 sm:border-t-0 sm:px-0 sm:py-3 sm:hover:w-screen sm:hover:rounded-none"
       >
         <PlayIcon className="w-3.5 h-3.5 text-sage-500" />
         Get Started

--- a/app/ui/dashboard/page.tsx
+++ b/app/ui/dashboard/page.tsx
@@ -8,6 +8,7 @@ export default function DashboardPage() {
      * Break out of the layout's mobile and desktop padding so the map fills
      * edge-to-edge. 100svh + overflow-hidden ensures the map gets a
      * concrete, mobile-safe height to render into (RouteMap uses h-full internally).
+     * Keep this wrapper in sync with the responsive RouteMap layout.
      */
     <div className="-mx-4 -mb-4 -mt-16 sm:-mx-6 sm:-mb-6 sm:-mt-16 md:-m-12 h-[100svh] overflow-hidden relative">
       <RouteMap />


### PR DESCRIPTION
## Summary
- Switch dashboard viewport sizing to mobile-safe `100svh` and reduce mobile padding around dashboard content
- Make the route map fill the mobile screen with the route/area panel as a scrollable bottom sheet
- Adjust the Get Started action so it no longer expands across small screens or crowds the mobile nav

## Test Plan
- [x] `source ~/.nvm/nvm.sh && nvm use 20.9.0 >/dev/null && pnpm build`