### PR TITLE
feat: add public training landing pages

### DIFF
--- a/app/bouldering-training-program/page.tsx
+++ b/app/bouldering-training-program/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { landingPageBySlug } from '@/app/lib/marketing/landing-pages';
+import MarketingLandingPage from '@/app/ui-components/marketing/marketing-landing-page';
+
+const page = landingPageBySlug['bouldering-training-program'];
+
+export const metadata: Metadata = {
+  title: `${page.title} | ClimbTrackr`,
+  description: page.metaDescription,
+};
+
+export default function Page() {
+  return <MarketingLandingPage page={page} />;
+}

--- a/app/climbing-endurance-workouts/page.tsx
+++ b/app/climbing-endurance-workouts/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { landingPageBySlug } from '@/app/lib/marketing/landing-pages';
+import MarketingLandingPage from '@/app/ui-components/marketing/marketing-landing-page';
+
+const page = landingPageBySlug['climbing-endurance-workouts'];
+
+export const metadata: Metadata = {
+  title: `${page.title} | ClimbTrackr`,
+  description: page.metaDescription,
+};
+
+export default function Page() {
+  return <MarketingLandingPage page={page} />;
+}

--- a/app/climbing-training-plan/page.tsx
+++ b/app/climbing-training-plan/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { landingPageBySlug } from '@/app/lib/marketing/landing-pages';
+import MarketingLandingPage from '@/app/ui-components/marketing/marketing-landing-page';
+
+const page = landingPageBySlug['climbing-training-plan'];
+
+export const metadata: Metadata = {
+  title: `${page.title} | ClimbTrackr`,
+  description: page.metaDescription,
+};
+
+export default function Page() {
+  return <MarketingLandingPage page={page} />;
+}

--- a/app/hangboard-training-for-beginners/page.tsx
+++ b/app/hangboard-training-for-beginners/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import { landingPageBySlug } from '@/app/lib/marketing/landing-pages';
+import MarketingLandingPage from '@/app/ui-components/marketing/marketing-landing-page';
+
+const page = landingPageBySlug['hangboard-training-for-beginners'];
+
+export const metadata: Metadata = {
+  title: `${page.title} | ClimbTrackr`,
+  description: page.metaDescription,
+};
+
+export default function Page() {
+  return <MarketingLandingPage page={page} />;
+}

--- a/app/lib/marketing/landing-pages.ts
+++ b/app/lib/marketing/landing-pages.ts
@@ -1,0 +1,280 @@
+export type LandingPageSlug =
+  | 'climbing-training-plan'
+  | 'bouldering-training-program'
+  | 'hangboard-training-for-beginners'
+  | 'climbing-endurance-workouts';
+
+export type LandingPage = {
+  slug: LandingPageSlug;
+  title: string;
+  shortTitle: string;
+  description: string;
+  metaDescription: string;
+  eyebrow: string;
+  heroTitle: string;
+  heroLead: string;
+  audience: string;
+  outcomes: string[];
+  sections: {
+    heading: string;
+    body: string;
+    bullets: string[];
+  }[];
+  sampleWeek: {
+    day: string;
+    focus: string;
+    details: string;
+  }[];
+  faqs: {
+    question: string;
+    answer: string;
+  }[];
+};
+
+export const landingPages: LandingPage[] = [
+  {
+    slug: 'climbing-training-plan',
+    title: 'Climbing Training Plan',
+    shortTitle: 'Training Plans',
+    description: 'Build a structured climbing training plan that balances strength, skill, endurance, recovery, and real climbing days.',
+    metaDescription:
+      'Learn how to build a climbing training plan for bouldering, sport climbing, and general climbing fitness with ClimbTrackr.',
+    eyebrow: 'Climbing training guide',
+    heroTitle: 'Build a climbing training plan you can actually follow',
+    heroLead:
+      'ClimbTrackr helps climbers turn vague goals into structured training blocks with workouts, exercises, programs, and progress tracking in one place.',
+    audience: 'Climbers who want a repeatable weekly structure instead of random sessions.',
+    outcomes: [
+      'Plan strength, technique, power, endurance, and recovery days.',
+      'Track what you actually completed after each session.',
+      'Adjust your next block based on real progress instead of guesswork.',
+    ],
+    sections: [
+      {
+        heading: 'Start with the goal, then build the week',
+        body:
+          'A useful climbing training plan starts with one clear objective: stronger fingers, better redpoint endurance, more powerful bouldering, or a durable base phase. Once the goal is clear, the weekly schedule becomes easier to build.',
+        bullets: [
+          'Pick one primary focus for the block.',
+          'Place hard climbing and strength sessions before lower-intensity volume.',
+          'Protect rest days so adaptation can happen.',
+        ],
+      },
+      {
+        heading: 'Use programs to keep sessions consistent',
+        body:
+          'ClimbTrackr programs make it easier to repeat proven sessions, compare performance over time, and avoid rebuilding every workout from scratch.',
+        bullets: [
+          'Save repeatable workouts for each training focus.',
+          'Group exercises into complete programs.',
+          'Use your history to decide when to progress volume or intensity.',
+        ],
+      },
+    ],
+    sampleWeek: [
+      { day: 'Monday', focus: 'Limit bouldering', details: 'High-quality attempts on hard moves with full rests.' },
+      { day: 'Tuesday', focus: 'Mobility and antagonist work', details: 'Shoulders, wrists, hips, and light pushing strength.' },
+      { day: 'Wednesday', focus: 'Finger strength', details: 'Structured hangboard or board climbing session.' },
+      { day: 'Thursday', focus: 'Rest', details: 'No hard climbing; easy walk or mobility only.' },
+      { day: 'Friday', focus: 'Power endurance', details: 'Intervals, linked boulders, or route laps.' },
+      { day: 'Weekend', focus: 'Outdoor or gym climbing', details: 'Apply the week’s training to real climbing goals.' },
+    ],
+    faqs: [
+      {
+        question: 'How many days per week should climbers train?',
+        answer:
+          'Most climbers make better progress with two to four focused sessions per week than with constant low-quality fatigue. The right number depends on climbing age, recovery, and goals.',
+      },
+      {
+        question: 'Can beginners use a climbing training plan?',
+        answer:
+          'Yes, but beginner plans should emphasize movement practice, gradual volume, basic strength, and recovery rather than aggressive hangboard or campus training.',
+      },
+    ],
+  },
+  {
+    slug: 'bouldering-training-program',
+    title: 'Bouldering Training Program',
+    shortTitle: 'Bouldering Program',
+    description: 'Train for stronger bouldering with focused sessions for power, tension, contact strength, movement skill, and recovery.',
+    metaDescription:
+      'Create a bouldering training program for power, finger strength, body tension, and movement skill with ClimbTrackr.',
+    eyebrow: 'Bouldering performance',
+    heroTitle: 'Create a bouldering training program for harder problems',
+    heroLead:
+      'A good bouldering program blends limit attempts, finger strength, body tension, movement practice, and enough recovery to actually get stronger.',
+    audience: 'Boulderers who want more powerful movement and better session structure.',
+    outcomes: [
+      'Organize limit bouldering, volume, and strength work across the week.',
+      'Track attempts, exercises, and completed workouts.',
+      'Build repeatable power-focused programs inside ClimbTrackr.',
+    ],
+    sections: [
+      {
+        heading: 'Separate limit climbing from volume days',
+        body:
+          'Hard bouldering requires freshness. Treat limit bouldering like strength training: lower volume, longer rests, and high intent. Save volume circuits for a different day.',
+        bullets: [
+          'Warm up gradually before hard attempts.',
+          'Rest long enough to make each try high quality.',
+          'Stop before sloppy attempts become the majority of the session.',
+        ],
+      },
+      {
+        heading: 'Track strength without losing the climbing focus',
+        body:
+          'Supplemental exercises should support climbing, not replace it. ClimbTrackr helps you keep finger work, core, and pulling strength tied to the larger training plan.',
+        bullets: [
+          'Use short strength blocks after climbing or on separate days.',
+          'Keep records of loads, holds, sets, and perceived effort.',
+          'Progress slowly enough to avoid finger and elbow flare-ups.',
+        ],
+      },
+    ],
+    sampleWeek: [
+      { day: 'Monday', focus: 'Limit bouldering', details: 'Project-level problems with long rests.' },
+      { day: 'Tuesday', focus: 'Core and antagonist strength', details: 'Tension drills, pushing, rotator cuff, and mobility.' },
+      { day: 'Wednesday', focus: 'Volume bouldering', details: 'Moderate problems, flash practice, and movement variety.' },
+      { day: 'Thursday', focus: 'Rest', details: 'Prioritize sleep, food, and easy mobility.' },
+      { day: 'Friday', focus: 'Power and fingers', details: 'Board climbing, max hangs, or contact strength work.' },
+      { day: 'Weekend', focus: 'Outdoor bouldering', details: 'Apply power and tactics on real rock.' },
+    ],
+    faqs: [
+      {
+        question: 'What should a bouldering training program include?',
+        answer:
+          'Most programs should include limit bouldering, moderate volume, finger strength, body tension, mobility, and rest. The exact mix depends on the climber’s weaknesses and goals.',
+      },
+      {
+        question: 'How long should a bouldering block last?',
+        answer:
+          'Four to eight weeks is a practical length for most climbers. It is long enough to repeat sessions and measure progress without staying locked into one focus forever.',
+      },
+    ],
+  },
+  {
+    slug: 'hangboard-training-for-beginners',
+    title: 'Hangboard Training for Beginners',
+    shortTitle: 'Hangboard Basics',
+    description: 'Learn how beginner climbers can approach hangboard training safely, progressively, and without replacing actual climbing practice.',
+    metaDescription:
+      'Beginner-friendly hangboard training guidance for climbers, including safety, progression, frequency, and tracking with ClimbTrackr.',
+    eyebrow: 'Finger strength basics',
+    heroTitle: 'Approach hangboard training with patience and structure',
+    heroLead:
+      'Hangboarding can help finger strength, but beginners need conservative progressions, careful tracking, and plenty of real climbing movement practice.',
+    audience: 'Newer climbers who want stronger fingers without rushing into risky training.',
+    outcomes: [
+      'Understand when hangboarding makes sense for newer climbers.',
+      'Track easy repeatable sessions instead of guessing intensity.',
+      'Keep finger training balanced with technique and recovery.',
+    ],
+    sections: [
+      {
+        heading: 'Earn the right to add intensity',
+        body:
+          'Many beginners improve quickly by climbing consistently, resting well, and practicing movement. Hangboard training should be added gradually and treated as a supplement.',
+        bullets: [
+          'Avoid maximal hangs if fingers or elbows are irritated.',
+          'Start with comfortable edges and controlled effort.',
+          'Stop sessions while form and tissue quality still feel good.',
+        ],
+      },
+      {
+        heading: 'Track small changes over time',
+        body:
+          'Finger training works best when progression is measured. ClimbTrackr can store the session details so you can progress edge size, assistance, load, or volume carefully.',
+        bullets: [
+          'Record edge size, hang time, assistance, and rest time.',
+          'Repeat a simple protocol long enough to see trends.',
+          'Increase only one variable at a time.',
+        ],
+      },
+    ],
+    sampleWeek: [
+      { day: 'Monday', focus: 'Technique climbing', details: 'Easy to moderate problems with footwork drills.' },
+      { day: 'Tuesday', focus: 'Rest or mobility', details: 'Shoulders, wrists, hips, and easy movement.' },
+      { day: 'Wednesday', focus: 'Intro finger session', details: 'Low-intensity hangs after a complete warm-up.' },
+      { day: 'Thursday', focus: 'Rest', details: 'Let fingers and elbows adapt.' },
+      { day: 'Friday', focus: 'Climbing volume', details: 'Moderate routes or boulders with good form.' },
+      { day: 'Weekend', focus: 'Optional easy climbing', details: 'Keep intensity low if fingers feel tired.' },
+    ],
+    faqs: [
+      {
+        question: 'Should beginners hangboard?',
+        answer:
+          'Some beginners can use very conservative hangboard sessions, but many should focus first on consistent climbing, technique, and general strength. Pain is a reason to stop, not push through.',
+      },
+      {
+        question: 'How often should a beginner hangboard?',
+        answer:
+          'One carefully controlled session per week is plenty for many newer climbers. More is not automatically better, especially if climbing volume is already high.',
+      },
+    ],
+  },
+  {
+    slug: 'climbing-endurance-workouts',
+    title: 'Climbing Endurance Workouts',
+    shortTitle: 'Endurance Workouts',
+    description: 'Improve route climbing endurance with structured laps, intervals, linked problems, aerobic base work, and recovery tracking.',
+    metaDescription:
+      'Plan climbing endurance workouts for sport climbing, route climbing, and long sessions with ClimbTrackr.',
+    eyebrow: 'Route climbing endurance',
+    heroTitle: 'Plan climbing endurance workouts that transfer to the wall',
+    heroLead:
+      'Endurance training works best when the workout matches the goal: easier mileage, pump management, power endurance, or longer outdoor days.',
+    audience: 'Route climbers, gym climbers, and outdoor climbers who pump out before the top.',
+    outcomes: [
+      'Choose the right endurance format for the goal.',
+      'Track laps, intervals, rest times, and perceived pump.',
+      'Build programs for base endurance and redpoint preparation.',
+    ],
+    sections: [
+      {
+        heading: 'Match the workout to the type of fatigue',
+        body:
+          'A climber falling from a short crux needs different training than a climber fading after thirty meters. ClimbTrackr helps organize both base endurance and power endurance sessions.',
+        bullets: [
+          'Use easy continuous mileage for aerobic base.',
+          'Use route intervals for pump management.',
+          'Use linked boulders or hard laps for power endurance.',
+        ],
+      },
+      {
+        heading: 'Measure rest as carefully as effort',
+        body:
+          'Endurance sessions are defined by work and rest. Tracking both makes it easier to repeat a workout and see whether capacity is improving.',
+        bullets: [
+          'Record work time, rest time, number of laps, and intensity.',
+          'Keep technique smooth when fatigue rises.',
+          'Progress density gradually by adding work or reducing rest.',
+        ],
+      },
+    ],
+    sampleWeek: [
+      { day: 'Monday', focus: 'Easy mileage', details: 'Many moderate routes with relaxed movement.' },
+      { day: 'Tuesday', focus: 'Strength maintenance', details: 'Short pulling, core, and antagonist session.' },
+      { day: 'Wednesday', focus: 'Route intervals', details: 'Repeated climbs with controlled rests.' },
+      { day: 'Thursday', focus: 'Rest', details: 'Recover before higher intensity work.' },
+      { day: 'Friday', focus: 'Power endurance', details: 'Harder linked sections or 4x4-style intervals.' },
+      { day: 'Weekend', focus: 'Outdoor routes', details: 'Practice pacing, clipping stances, and redpoint tactics.' },
+    ],
+    faqs: [
+      {
+        question: 'What is the best climbing endurance workout?',
+        answer:
+          'The best workout depends on the limiter. Use easy mileage for base endurance, intervals for pump management, and linked hard climbing for power endurance.',
+      },
+      {
+        question: 'How do I know if endurance is improving?',
+        answer:
+          'Track the same or similar workouts over time. Improvements may show up as more laps, less pump, shorter rests, better pacing, or better performance on longer climbs.',
+      },
+    ],
+  },
+];
+
+export const landingPageBySlug = landingPages.reduce(
+  (pages, page) => ({ ...pages, [page.slug]: page }),
+  {} as Record<LandingPageSlug, LandingPage>,
+);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { Exercise } from '@/app/lib/exercise/exercise';
 import { getUserCount } from '@/app/lib/account/account-actions';
 import { getWorkoutCount } from '@/app/lib/workout/workout-actions';
 import HeroSection from '@/app/ui-components/home/hero-section';
+import { landingPages } from '@/app/lib/marketing/landing-pages';
 
 export default async function Page() {
   const exerciseCount = await Exercise.countFiltered('');
@@ -71,6 +72,48 @@ export default async function Page() {
                 Connect with fellow climbers and share your achievements and challenges.
               </p>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Training Resources Section */}
+      <section className="py-20 bg-white">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between mb-12">
+            <div>
+              <p className="text-sm font-bold uppercase tracking-[0.25em] text-sage-600 mb-3">Training resources</p>
+              <h2 className={`${lusitana.className} text-3xl md:text-4xl font-bold text-stone-800 mb-4`}>
+                Learn How to Train for Climbing
+              </h2>
+              <p className="text-lg text-stone-600 max-w-2xl">
+                Explore practical climbing training guides, then use ClimbTrackr to turn those ideas into repeatable exercises, programs, and logged workouts.
+              </p>
+            </div>
+            <Link
+              href="/climbing-training-plan"
+              className="inline-flex items-center justify-center gap-2 rounded-lg border-2 border-sage-500 px-5 py-3 font-semibold text-sage-600 transition-colors hover:bg-sage-500 hover:text-white"
+            >
+              Start with training plans
+              <ArrowRightIcon className="w-5 h-5" />
+            </Link>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+            {landingPages.map((page) => (
+              <Link
+                key={page.slug}
+                href={`/${page.slug}`}
+                className="group flex h-full flex-col rounded-xl bg-stone-100 p-6 shadow-md transition-all duration-300 hover:-translate-y-1 hover:shadow-xl"
+              >
+                <p className="mb-3 text-xs font-bold uppercase tracking-[0.2em] text-sage-600">{page.eyebrow}</p>
+                <h3 className="mb-3 text-xl font-bold text-stone-800 group-hover:text-sage-600">{page.shortTitle}</h3>
+                <p className="mb-6 flex-1 text-stone-600">{page.description}</p>
+                <span className="inline-flex items-center gap-2 font-semibold text-sage-600">
+                  Read the guide
+                  <ArrowRightIcon className="w-5 h-5 transition-transform group-hover:translate-x-1" />
+                </span>
+              </Link>
+            ))}
           </div>
         </div>
       </section>

--- a/app/ui-components/marketing/marketing-landing-page.tsx
+++ b/app/ui-components/marketing/marketing-landing-page.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link';
+import { ArrowRightIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import { lusitana } from '@/app/ui-components/fonts';
+import type { LandingPage } from '@/app/lib/marketing/landing-pages';
+
+export default function MarketingLandingPage({ page }: { page: LandingPage }) {
+  return (
+    <main className="min-h-screen bg-stone-100 text-stone-800">
+      <section className="bg-gradient-to-br from-sage-600 via-sage-500 to-brown-500 text-white">
+        <div className="mx-auto max-w-6xl px-6 py-20 md:py-28">
+          <Link href="/" className="mb-10 inline-flex text-sm font-semibold text-stone-100 hover:text-white">
+            ← Back to ClimbTrackr
+          </Link>
+          <div className="max-w-3xl">
+            <p className="mb-4 text-sm font-bold uppercase tracking-[0.3em] text-stone-100">{page.eyebrow}</p>
+            <h1 className={`${lusitana.className} mb-6 text-4xl font-bold md:text-6xl`}>{page.heroTitle}</h1>
+            <p className="mb-8 text-xl leading-8 text-stone-100 md:text-2xl">{page.heroLead}</p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/ui/signup"
+                className="inline-flex items-center justify-center gap-3 rounded-lg bg-white px-7 py-4 text-lg font-semibold text-sage-600 shadow-lg transition-all duration-300 hover:scale-105 hover:bg-stone-100"
+              >
+                Start building your plan
+                <ArrowRightIcon className="h-5 w-5" />
+              </Link>
+              <Link
+                href="/ui/login"
+                className="inline-flex items-center justify-center rounded-lg border-2 border-white px-7 py-4 text-lg font-semibold text-white transition-colors hover:bg-white hover:text-sage-600"
+              >
+                Log in
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto grid max-w-6xl gap-8 px-6 lg:grid-cols-[1fr_360px]">
+          <article className="space-y-8">
+            <div className="rounded-2xl bg-white p-8 shadow-lg">
+              <p className="text-lg leading-8 text-stone-600">{page.description}</p>
+              <div className="mt-8 grid gap-4 md:grid-cols-3">
+                {page.outcomes.map((outcome) => (
+                  <div key={outcome} className="rounded-xl bg-stone-100 p-5">
+                    <CheckCircleIcon className="mb-3 h-6 w-6 text-sage-600" />
+                    <p className="font-medium text-stone-700">{outcome}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {page.sections.map((section) => (
+              <section key={section.heading} className="rounded-2xl bg-white p-8 shadow-lg">
+                <h2 className={`${lusitana.className} mb-4 text-3xl font-bold text-stone-800`}>{section.heading}</h2>
+                <p className="mb-6 text-lg leading-8 text-stone-600">{section.body}</p>
+                <ul className="space-y-3">
+                  {section.bullets.map((bullet) => (
+                    <li key={bullet} className="flex gap-3 text-stone-700">
+                      <span className="mt-2 h-2 w-2 flex-none rounded-full bg-sage-500" />
+                      <span>{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+
+            <section className="rounded-2xl bg-white p-8 shadow-lg">
+              <h2 className={`${lusitana.className} mb-6 text-3xl font-bold text-stone-800`}>Sample weekly structure</h2>
+              <div className="grid gap-4 md:grid-cols-2">
+                {page.sampleWeek.map((item) => (
+                  <div key={`${item.day}-${item.focus}`} className="rounded-xl border border-stone-200 bg-stone-100 p-5">
+                    <p className="text-sm font-bold uppercase tracking-wide text-sage-600">{item.day}</p>
+                    <h3 className="mt-2 text-lg font-bold text-stone-800">{item.focus}</h3>
+                    <p className="mt-2 text-stone-600">{item.details}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-2xl bg-white p-8 shadow-lg">
+              <h2 className={`${lusitana.className} mb-6 text-3xl font-bold text-stone-800`}>Common questions</h2>
+              <div className="space-y-6">
+                {page.faqs.map((faq) => (
+                  <div key={faq.question}>
+                    <h3 className="text-xl font-bold text-stone-800">{faq.question}</h3>
+                    <p className="mt-2 leading-7 text-stone-600">{faq.answer}</p>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </article>
+
+          <aside className="space-y-6">
+            <div className="sticky top-6 rounded-2xl bg-white p-8 shadow-lg">
+              <p className="text-sm font-bold uppercase tracking-[0.2em] text-sage-600">Best for</p>
+              <p className="mt-3 text-lg font-semibold text-stone-800">{page.audience}</p>
+              <div className="my-6 h-px bg-stone-200" />
+              <h2 className={`${lusitana.className} text-2xl font-bold text-stone-800`}>Track it in ClimbTrackr</h2>
+              <p className="mt-3 text-stone-600">
+                Save exercises, organize programs, log workouts, and keep your climbing training history in one focused place.
+              </p>
+              <Link
+                href="/ui/signup"
+                className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-sage-500 px-5 py-3 font-semibold text-white transition-colors hover:bg-sage-600"
+              >
+                Get started free
+                <ArrowRightIcon className="h-5 w-5" />
+              </Link>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add four SEO-friendly public climbing training landing pages
- Add a reusable marketing landing page component and shared page content data
- Add a homepage training resources section linking to the new guides

## New public pages
- /climbing-training-plan
- /bouldering-training-program
- /hangboard-training-for-beginners
- /climbing-endurance-workouts

## Test Plan
- [x] `source ~/.nvm/nvm.sh && nvm use 20.9.0 >/dev/null && pnpm build`