### PR TITLE
fix: render homepage stats dynamically

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import { getWorkoutCount } from '@/app/lib/workout/workout-actions';
 import HeroSection from '@/app/ui-components/home/hero-section';
 import { landingPages } from '@/app/lib/marketing/landing-pages';
 
+export const dynamic = 'force-dynamic';
+
 export default async function Page() {
   const exerciseCount = await Exercise.countFiltered('');
   const userCount = await getUserCount();


### PR DESCRIPTION
## Summary
- Force the homepage route to render dynamically so DB-backed stats stay current
- Keeps exercise/user/workout counts from being frozen in Vercel's prerendered cache

## Test Plan
- [x] `source ~/.nvm/nvm.sh && nvm use 20.9.0 >/dev/null && pnpm build`
- [x] Confirmed build output marks `/` as dynamic (ƒ)